### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "~5.4|~5.5",
-    "illuminate/queue": "~5.4|~5.5",
-    "illuminate/auth": "~5.4|~5.5",
+    "illuminate/support": "5.4.*|5.5.*",
+    "illuminate/queue": "5.4.*|5.5.*",
+    "illuminate/auth": "~5.4.*|5.5.*",
     "nesbot/carbon": "~1.20"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     "php": ">=5.6.4",
     "illuminate/support": "5.4.*|5.5.*",
     "illuminate/queue": "5.4.*|5.5.*",
-    "illuminate/auth": "~5.4.*|5.5.*",
+    "illuminate/auth": "5.4.*|5.5.*",
     "nesbot/carbon": "~1.20"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",
     "phpunit/phpunit": "^5.7|6.2",
     "orchestra/testbench": "~3.4.2|~3.5.0",
-    "laravel/framework": "~5.4.0|~5.5.0"
+    "laravel/framework": "5.4.*|5.5.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.